### PR TITLE
Fix Error from Cocoapod when pod install

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,10 +1,10 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-target 'IOCipherTests', :exclusive => true do
+target 'IOCipherTests' do
   pod "IOCipher", :path => "../"
 end
 
-target 'IOCipherServer', :exclusive => true do
+target 'IOCipherServer' do
   pod "IOCipher/GCDWebServer", :path => "../"
 end
 

--- a/IOCipher.podspec
+++ b/IOCipher.podspec
@@ -5,11 +5,12 @@ Pod::Spec.new do |s|
   s.homepage         = "https://github.com/chrisballinger/IOCipher"
   s.license          = 'LGPLv2.1+'
   s.author           = { "Chris Ballinger" => "chris@chatsecure.org" }
-  s.source           = { :git => "https://github.com/IOCipher-ObjC.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/chrisballinger/IOCipher.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/ChatSecure'
 
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.8'
+  s.requires_arc = true
 
   s.default_subspec = 'standard'
 

--- a/IOCipher.podspec
+++ b/IOCipher.podspec
@@ -5,12 +5,11 @@ Pod::Spec.new do |s|
   s.homepage         = "https://github.com/chrisballinger/IOCipher"
   s.license          = 'LGPLv2.1+'
   s.author           = { "Chris Ballinger" => "chris@chatsecure.org" }
-  s.source           = { :git => "https://github.com/chrisballinger/IOCipher.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/IOCipher-ObjC.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/ChatSecure'
 
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.8'
-  s.requires_arc = true
 
   s.default_subspec = 'standard'
 


### PR DESCRIPTION
$ pod install

[!] Invalid `Podfile` file: [!] Unsupported options `{:exclusive=>true}` for target `IOCipherTests`..

 #  from /Users/username/Downloads/IOCipher-ObjC/Example/Podfile:3
 #  -------------------------------------------
 #  

>  target 'IOCipherTests', :exclusive => true do
>  #    pod "IOCipher", :path => "../"
>  #  -------------------------------------------
